### PR TITLE
Update e2e tests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 scarb 2.6.3
+starknet-foundry 0.19.0 

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -6,9 +6,15 @@ name = "erc4906"
 version = "0.1.0"
 dependencies = [
  "openzeppelin",
+ "snforge_std",
 ]
 
 [[package]]
 name = "openzeppelin"
 version = "0.10.0"
 source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.10.0#d77082732daab2690ba50742ea41080eb23299d3"
+
+[[package]]
+name = "snforge_std"
+version = "0.19.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.19.0#a3391dce5bdda51c63237032e6cfc64fb7a346d4"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,6 +10,10 @@ cairo-version = "2.6.3"
 [dependencies]
 starknet = "2.6.3"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.10.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.19.0" }
+
+[scripts]
+test = "snforge test"
 
 [lib]
 

--- a/src/ERC4906.cairo
+++ b/src/ERC4906.cairo
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 #[starknet::interface]
-trait IERC4906Helper<TContractState> {
+pub trait IERC4906Helper<TContractState> { // TODO: remove pub keyword
     fn set_base_token_uri(ref self: TContractState, token_uri: ByteArray);
 }
 
@@ -22,9 +22,9 @@ pub mod ERC4906Component {
     }
 
     #[derive(Drop, PartialEq, starknet::Event)]
-    struct MetadataUpdate {
+    pub struct MetadataUpdate { // TODO: remove pub keyword
         #[key]
-        token_uri: ByteArray,
+        pub token_uri: ByteArray, // Same here
     }
 
     #[derive(Drop, PartialEq, starknet::Event)]

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,2 +1,7 @@
 mod ERC4906;
 mod presets;
+
+#[cfg(test)]
+mod tests {
+    mod test_e2e;
+}

--- a/src/tests/test_e2e.cairo
+++ b/src/tests/test_e2e.cairo
@@ -1,0 +1,83 @@
+// Contracts
+
+use erc4906::ERC4906::ERC4906Component;
+use erc4906::ERC4906::ERC4906Component::{Event, MetadataUpdate};
+
+// Components
+
+use erc4906::ERC4906::{IERC4906Helper, IERC4906HelperDispatcher, IERC4906HelperDispatcherTrait};
+use openzeppelin::token::erc721::interface::{IERC721MetadataDispatcher, IERC721MetadataDispatcherTrait, IERC721Metadata};
+
+// External deps
+
+use openzeppelin::utils::serde::SerializedAppend;
+use snforge_std as snf;
+use snforge_std::{CheatTarget, ContractClassTrait, EventSpy, SpyOn, cheatcodes::events::EventAssertions};
+
+// Starknet deps
+
+use starknet::{ContractAddress, contract_address_const};
+
+// Constants
+fn NAME() -> ByteArray {
+    "NAME"
+}
+
+fn SYMBOL() -> ByteArray {
+    "SYMBOL"
+}
+fn BASE_URI() -> ByteArray {
+    "https://api.example.com/v1/"
+}
+fn OTHER_BASE_URI() -> ByteArray {
+    "https://api.example.com/v2/"
+}
+fn OTHER() -> ContractAddress {
+    contract_address_const::<'OTHER'>()
+}
+fn OWNER() -> ContractAddress {
+    contract_address_const::<'OWNER'>()
+}
+const TOKEN_1: u256 = 1;
+const TOKEN_10: u256 = 10;
+
+// Deploys an ERC721MetadaUpdate contract.
+fn deploy() -> (ContractAddress, EventSpy) {
+    let contract = snf::declare("ERC721MetadataUpdate");
+
+    let token_ids = array![TOKEN_1, TOKEN_10];
+    let mut calldata: Array<felt252> = array![];
+    calldata.append_serde(NAME());
+    calldata.append_serde(SYMBOL());
+    calldata.append_serde(BASE_URI());
+    calldata.append_serde(OTHER());
+    calldata.append_serde(token_ids);
+    calldata.append_serde(OWNER());
+
+    let contract_address = contract.deploy(@calldata).unwrap();
+    let mut spy = snf::spy_events(SpyOn::One(contract_address));
+
+    (contract_address, spy)
+}
+
+#[test]
+fn test_set_token_uri() {
+    let (contract_address, mut spy) = deploy();
+    let erc721_meta = IERC721MetadataDispatcher { contract_address };
+    let erc4906 = IERC4906HelperDispatcher { contract_address };
+
+    assert(erc721_meta.token_uri(TOKEN_1) == "https://api.example.com/v1/1", 'Wrong init token uri');
+
+    snf::start_prank(CheatTarget::One(contract_address), OWNER());
+    erc4906.set_base_token_uri(OTHER_BASE_URI());
+
+    assert(erc721_meta.token_uri(TOKEN_1) == "https://api.example.com/v2/1", 'Wrong token uri');
+
+    let expected_metadata_update = MetadataUpdate { token_uri: OTHER_BASE_URI() };
+    spy.
+        assert_emitted(
+            @array![
+                (contract_address, Event::MetadataUpdate(expected_metadata_update))
+            ]
+        )
+}


### PR DESCRIPTION
Hey,

Tests working, but I have a problem related to importing modules. I added a couple `pub` keywords to get my imports to work while I usually don't have to do that. I am familiar with how imports work and read the book, but somehow I am missing something here. I would appreciate if someone could tell me what it is :)

Additionally, I am not sure how I can update the test `test_emit_batch_metadata_revert_not_owner` from the cairo 0 repo. I feel like it's not relevant since the only preset implemented at the moment doesn't make use of `emitBatchMetadataUpdate`.

Related to issue #3 